### PR TITLE
Add a delegate method that includes the filePath of newly extracted files

### DIFF
--- a/SSZipArchive.h
+++ b/SSZipArchive.h
@@ -42,4 +42,5 @@
 - (void)zipArchiveWillUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 - (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 
+- (void)zipArchiveDidUnzipArchiveFile:(NSString *)zipFile entryPath:(NSString *)entryPath destPath:(NSString *)destPath;
 @end

--- a/SSZipArchive.m
+++ b/SSZipArchive.m
@@ -240,7 +240,10 @@
 			[delegate zipArchiveDidUnzipFileAtIndex:currentFileNumber totalFiles:(NSInteger)globalInfo.number_entry
 										 archivePath:path fileInfo:fileInfo];
 		}
-		
+        if ([delegate respondsToSelector:@selector(zipArchiveDidUnzipArchiveFile:entryPath:destPath:)]) {
+            [delegate zipArchiveDidUnzipArchiveFile:path entryPath:strPath destPath:fullPath];
+        }
+
 		currentFileNumber++;
 	} while(ret == UNZ_OK && UNZ_OK != UNZ_END_OF_LIST_OF_FILE);
 	

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name            = 'SSZipArchive'
-  s.version         = '0.2.3'
+  s.version         = '0.2.2.1'
   s.summary         = 'Utility class for zipping and unzipping files on iOS and Mac.'
   s.homepage        = 'https://github.com/samsoffes/ssziparchive'
   s.author          = { 'Sam Soffes' => 'sam@samsoff.es' }
-  s.source          = { :git => 'https://github.com/samsoffes/ssziparchive.git', :tag => '0.2.2' }
+  s.source          = { :git => 'https://github.com/samsoffes/ssziparchive.git', :tag => s.version.to_s }
   s.description     = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS and Mac.'
   s.source_files    = 'SSZipArchive.{h,m}', 'minizip/*.{h,c}'
   s.library         = 'z'

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary         = 'Utility class for zipping and unzipping files on iOS and Mac.'
   s.homepage        = 'https://github.com/samsoffes/ssziparchive'
   s.author          = { 'Sam Soffes' => 'sam@samsoff.es' }
-  s.source          = { :git => 'https://github.com/samsoffes/ssziparchive.git', :tag => s.version.to_s }
+  s.source          = { :git => 'git@github.com:955dreams/ssziparchive.git', :tag => s.version.to_s }
   s.description     = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS and Mac.'
   s.source_files    = 'SSZipArchive.{h,m}', 'minizip/*.{h,c}'
   s.library         = 'z'

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = 'SSZipArchive'
-  s.version         = '0.2.2'
+  s.version         = '0.2.3'
   s.summary         = 'Utility class for zipping and unzipping files on iOS and Mac.'
   s.homepage        = 'https://github.com/samsoffes/ssziparchive'
   s.author          = { 'Sam Soffes' => 'sam@samsoff.es' }

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -11,3 +11,4 @@ Pod::Spec.new do |s|
   s.preserve_paths  = ['Tests', '.gitignore']
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.header_mappings_dir = '.'
+end

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.author          = { 'Sam Soffes' => 'sam@samsoff.es' }
   s.source          = { :git => 'https://github.com/samsoffes/ssziparchive.git', :tag => '0.2.2' }
   s.description     = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS and Mac.'
-  s.source_files    = 'SSZipArchive.*', 'minizip/*.{h,c}'
+  s.source_files    = 'SSZipArchive.{h,m}', 'minizip/*.{h,c}'
   s.library         = 'z'
   s.preserve_paths  = ['Tests', '.gitignore']
   s.license      = { :type => 'MIT', :file => 'LICENSE' }

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -10,9 +10,4 @@ Pod::Spec.new do |s|
   s.library         = 'z'
   s.preserve_paths  = ['Tests', '.gitignore']
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
-
-  # Maintain the dir structure for headers
-  def s.copy_header_mapping(from)
-    from
-  end
-end
+  s.header_mappings_dir = '.'

--- a/Tests/CollectingDelegate.h
+++ b/Tests/CollectingDelegate.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+/**
+* Test delegate by collecting its calls
+*/
+@interface CollectingDelegate : NSObject <SSZipArchiveDelegate>
+@property(nonatomic, retain) NSMutableArray *files;
+@end

--- a/Tests/CollectingDelegate.m
+++ b/Tests/CollectingDelegate.m
@@ -1,0 +1,35 @@
+//
+// Created by chris on 8/1/12.
+//
+// To change the template use AppCode | Preferences | File Templates.
+//
+
+
+#import "SSZipArchive.h"
+#import "CollectingDelegate.h"
+
+@implementation CollectingDelegate {
+
+}
+@synthesize files = _files;
+
+
+- (id)init {
+    self = [super init];
+    if (self) {
+        self.files = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)zipArchiveDidUnzipArchiveFile:(NSString *)zipFile entryPath:(NSString *)entryPath destPath:(NSString *)destPath {
+    [self.files addObject:entryPath];
+}
+
+- (void)dealloc {
+    [_files release];
+    [super dealloc];
+}
+
+
+@end

--- a/Tests/SSZipArchive.xcodeproj/project.pbxproj
+++ b/Tests/SSZipArchive.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5A416BA09CD6A335F551C015 /* CollectingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A416109F75BF6E777908B04 /* CollectingDelegate.m */; };
 		B215FB32143AD3C7003AC546 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B215FB31143AD3C7003AC546 /* SenTestingKit.framework */; };
 		B215FB63143AD514003AC546 /* SSZipArchiveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B215FB61143AD514003AC546 /* SSZipArchiveTests.m */; };
 		B215FB65143AD527003AC546 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B215FB64143AD527003AC546 /* libz.dylib */; };
@@ -24,6 +25,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5A416109F75BF6E777908B04 /* CollectingDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CollectingDelegate.m; sourceTree = "<group>"; };
+		5A4164B83A2827BFD88C3CA1 /* CollectingDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CollectingDelegate.h; sourceTree = "<group>"; };
 		B215FB18143AD3C7003AC546 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		B215FB30143AD3C7003AC546 /* SSZipArchiveTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SSZipArchiveTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B215FB31143AD3C7003AC546 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -120,6 +123,8 @@
 		B215FB5E143AD505003AC546 /* SSZipArchiveTests */ = {
 			isa = PBXGroup;
 			children = (
+				5A416109F75BF6E777908B04 /* CollectingDelegate.m */,
+				5A4164B83A2827BFD88C3CA1 /* CollectingDelegate.h */,
 				B2283D5C155AD80F00F9395A /* Unicode.zip */,
 				B215FB61143AD514003AC546 /* SSZipArchiveTests.m */,
 				B215FB5F143AD514003AC546 /* SSZipArchiveTests-Info.plist */,
@@ -220,6 +225,7 @@
 				B215FB69143AD576003AC546 /* mztools.c in Sources */,
 				B215FB6A143AD576003AC546 /* unzip.c in Sources */,
 				B215FB6B143AD576003AC546 /* zip.c in Sources */,
+				5A416BA09CD6A335F551C015 /* CollectingDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/SSZipArchiveTests.m
+++ b/Tests/SSZipArchiveTests.m
@@ -7,6 +7,7 @@
 //
 
 #import "SSZipArchive.h"
+#import "CollectingDelegate.h"
 #import <SenTestingKit/SenTestingKit.h>
 #import <CommonCrypto/CommonDigest.h>
 
@@ -131,6 +132,16 @@
 //	[SSZipArchive unzipFileAtPath:zipPath toDestination:outputPath];
 //}
 
+-(void)testShouldProvidePathOfUnzippedFileInDelegateCallback {
+    CollectingDelegate *collector = [[CollectingDelegate new] autorelease];
+    NSString *zipPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestArchive" ofType:@"zip"];
+   	NSString *outputPath = [self _cachesPath:@"Regular"];
+
+   	[SSZipArchive unzipFileAtPath:zipPath toDestination:outputPath delegate:collector];
+
+    STAssertEqualObjects([collector.files objectAtIndex:0], @"LICENSE", nil);
+    STAssertEqualObjects([collector.files objectAtIndex:1], @"Readme.markdown", nil);
+}
 
 #pragma mark - SSZipArchiveDelegate
 


### PR DESCRIPTION
Currently the delegate methods send a file_info structure that provides some context for what has just been unzipped. But it does not provide the name of the file that was unzipped. I have added a delegate method that does report the name of the file so that the receiver can perform and tasks that are needed for that file. 