### PR TITLE
writeFileAtPath does not close file handle

### DIFF
--- a/SSZipArchive.m
+++ b/SSZipArchive.m
@@ -412,6 +412,9 @@
     
 	zipCloseFileInZip(_zip);
 	free(buffer);
+    fclose(input);
+    input = NULL;
+    
 	return YES;
 }
 


### PR DESCRIPTION
In SSZipArchive.m:L377, writeFileAtPath opens a file handle but never closes it:

```objective-c
- (BOOL)writeFileAtPath:(NSString *)path withFileName:(NSString *)fileName {
    NSAssert((_zip != NULL), @"Attempting to write to an archive which was never opened");
    
	FILE *input = fopen([path UTF8String], "r");
	if (NULL == input) {
		return NO;
	}
```

This needs to call fclose if fopen succeeds