### PR TITLE
Cancelable zip progress

### DIFF
--- a/SSZipArchive.h
+++ b/SSZipArchive.h
@@ -24,7 +24,11 @@
 + (BOOL)unzipFileAtPath:(NSString *)path toDestination:(NSString *)destination overwrite:(BOOL)overwrite password:(NSString *)password error:(NSError **)error delegate:(id<SSZipArchiveDelegate>)delegate;
 
 // Zip
-+ (BOOL)createZipFileAtPath:(NSString *)path withFilesAtPaths:(NSArray *)filenames;
++ (BOOL)createZipFileAtPath:(NSString *)path
+           withFilesAtPaths:(NSArray *)filenames;
++ (BOOL)createZipFileAtPath:(NSString *)path
+           withFilesAtPaths:(NSArray *)filenames
+                andDelegate:(id<SSZipArchiveDelegate>)delegate;
 + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath;
 
 - (id)initWithPath:(NSString *)path;
@@ -45,6 +49,9 @@
 
 - (void)zipArchiveWillUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 - (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
+
+- (BOOL)zipArchiveDidProgress:(NSUInteger)completed outOf:(NSUInteger)total;
+- (void)zipArchiveDidComplete:(BOOL)success;
 
 @end
 

--- a/SSZipArchive.m
+++ b/SSZipArchive.m
@@ -412,6 +412,9 @@
     
 	zipCloseFileInZip(_zip);
 	free(buffer);
+    fclose(input);
+    input = NULL;
+    
 	return YES;
 }
 

--- a/SSZipArchive.m
+++ b/SSZipArchive.m
@@ -279,12 +279,17 @@
 
 + (BOOL)createZipFileAtPath:(NSString *)path withFilesAtPaths:(NSArray *)paths {
 	BOOL success = NO;
+    BOOL error = NO;
 	SSZipArchive *zipArchive = [[SSZipArchive alloc] initWithPath:path];
 	if ([zipArchive open]) {
 		for (NSString *path in paths) {
-			[zipArchive writeFile:path];
+			if (![zipArchive writeFile:path])
+            {
+                error = YES;
+                break;
+            }
 		}
-		success = [zipArchive close];        
+		success = [zipArchive close] && !error;
 	}
 	
 #if !__has_feature(objc_arc)
@@ -297,6 +302,7 @@
 
 + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath {
     BOOL success = NO;
+    BOOL error = NO;
     
     NSFileManager *fileManager = nil;
 	SSZipArchive *zipArchive = [[SSZipArchive alloc] initWithPath:path];
@@ -312,10 +318,14 @@
             NSString *fullFilePath = [directoryPath stringByAppendingPathComponent:fileName];
             [fileManager fileExistsAtPath:fullFilePath isDirectory:&isDir];
             if (!isDir) {
-                [zipArchive writeFileAtPath:fullFilePath withFileName:fileName];
+                if (![zipArchive writeFileAtPath:fullFilePath withFileName:fileName])
+                {
+                    error = YES;
+                    break;
+                }
             }
         }
-        success = [zipArchive close];
+        success = [zipArchive close] && !error;
 	}
 	
 #if !__has_feature(objc_arc)
@@ -373,7 +383,7 @@
 // *fileName* is the relative name of the file how it is stored within the zip e.g. /folder/subfolder/text1.txt
 - (BOOL)writeFileAtPath:(NSString *)path withFileName:(NSString *)fileName {
     NSAssert((_zip != NULL), @"Attempting to write to an archive which was never opened");
-    
+    BOOL error = NO;
 	FILE *input = fopen([path UTF8String], "r");
 	if (NULL == input) {
 		return NO;
@@ -388,34 +398,43 @@
     }
     
     zip_fileinfo zipInfo = {{0}};
-
-    NSDictionary *attr = [[NSFileManager defaultManager] attributesOfItemAtPath:path error: nil];
-    if( attr )
-    {
-      NSDate *fileDate = (NSDate *)[attr objectForKey:NSFileModificationDate];
-      if( fileDate )
-      {
-        [self zipInfo:&zipInfo setDate: fileDate ];
-      }
-    }
-	
-    zipOpenNewFileInZip(_zip, afileName, NULL, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION);
     
-	void *buffer = malloc(CHUNK);
-	unsigned int len = 0;
-	
-    while (!feof(input))
+    if (!error)
     {
-		len = (unsigned int) fread(buffer, 1, CHUNK, input);
-		zipWriteInFileInZip(_zip, buffer, len);
+        NSDictionary *attr = [[NSFileManager defaultManager] attributesOfItemAtPath:path error: nil];
+        NSDate *fileDate = (NSDate *)[attr objectForKey:NSFileModificationDate];
+        if(fileDate)
+        {
+            [self zipInfo:&zipInfo setDate:fileDate];
+        }
+        
+        int openRes = zipOpenNewFileInZip(_zip, afileName, NULL, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_BEST_COMPRESSION);
+        if (openRes != ZIP_OK)
+            error = YES;
+    }
+    
+	unsigned int len = 0;
+    void* buffer = malloc(CHUNK);
+    if (!buffer)
+        error = YES;
+	
+    while (!error && !feof(input))
+    {
+		len = (unsigned int)fread(buffer, 1, CHUNK, input);
+		int writeRes = zipWriteInFileInZip(_zip, buffer, len);
+        if (writeRes != Z_OK)
+            error = YES;
 	}
     
-	zipCloseFileInZip(_zip);
+	int closeRes = zipCloseFileInZip(_zip);
+    if (closeRes != Z_OK)
+        error = YES;
+    
 	free(buffer);
     fclose(input);
     input = NULL;
     
-	return YES;
+	return !error;
 }
 
 
@@ -426,15 +445,27 @@
     if (!data) {
 		return NO;
     }
+    BOOL error = NO;
     zip_fileinfo zipInfo = {{0,0,0,0,0,0},0,0,0};
     [self zipInfo:&zipInfo setDate:[NSDate date]];
 
-	zipOpenNewFileInZip(_zip, [filename UTF8String], &zipInfo, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION);
+    
+	int openRes = zipOpenNewFileInZip(_zip, [filename UTF8String], &zipInfo, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION);
+    if (openRes != Z_OK)
+        error = YES;
 
-    zipWriteInFileInZip(_zip, data.bytes, (unsigned int)data.length);
+    if (!error)
+    {
+        int writeRes = zipWriteInFileInZip(_zip, data.bytes, (unsigned int)data.length);
+        if (writeRes != Z_OK)
+            error = YES;
+    }
 
-	zipCloseFileInZip(_zip);
-	return YES;
+	int closeRes = zipCloseFileInZip(_zip);
+    if (closeRes != Z_OK)
+        error = YES;
+
+	return !error;
 }
 
 


### PR DESCRIPTION
This adds an api to SSZipArchiveDelegate for canceling in progress zip operations. I only added support to createZipFileAtPath:withFilesAtPaths: and not createZipFileAtPath:withContentsOfDirectory: though the latter would be straightforward to add. 

The older commits in the branch are a few small bug fixes.