### PR TITLE
Fix clang analyzer warning appearing in line 1534

### DIFF
--- a/SSZipArchive/minizip/unzip.c
+++ b/SSZipArchive/minizip/unzip.c
@@ -1554,9 +1554,7 @@ extern int ZEXPORT unzOpenCurrentFile3 (unzFile file, int* method,
     pfile_in_zip_read_info->compression_method = s->cur_file_info.compression_method;
     pfile_in_zip_read_info->filestream=s->filestream;
     pfile_in_zip_read_info->z_filefunc=s->z_filefunc;
-#ifndef __clang_analyzer__
     pfile_in_zip_read_info->byte_before_the_zipfile=s->byte_before_the_zipfile;
-#endif
 
     pfile_in_zip_read_info->stream.total_out = 0;
 


### PR DESCRIPTION
Removing the clang analyzer silencer in these lines fixed another clang analyzer warning that appeared in line 1534.
In addition these lines do not cause a static analyzer warning in latest Xcode any longer.
Tested with Xcode 5.0.2