### PR TITLE
Fix implicit conversion warning

### DIFF
--- a/SSZipArchive/minizip/ioapi.c
+++ b/SSZipArchive/minizip/ioapi.c
@@ -192,7 +192,7 @@ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T
     }
     ret = 0;
 
-    if(fseeko64((FILE *)stream, offset, fseek_origin) != 0)
+    if(fseeko64((FILE *)stream, (long)offset, fseek_origin) != 0)
                         ret = -1;
 
     return ret;


### PR DESCRIPTION
I understand this file is originally part of MiniZip, but I think it would still be nice to fix the warning.

Duplicate of https://github.com/soffes/ssziparchive/issues/82

```
SSZipArchive/minizip/ioapi.c:195:33: Implicit conversion loses integer precision: 'ZPOS64_T' (aka 'unsigned long long') to 'long'
```