### PR TITLE
Fixed implicit conversion loses integer precision warnings

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -46,7 +46,7 @@
 - (void)zipArchiveWillUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 - (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 
-- (void)zipArchiveProgressEvent:(NSInteger)loaded total:(NSInteger)total;
+- (void)zipArchiveProgressEvent:(ZPOS64_T)loaded total:(ZPOS64_T)total;
 @end
 
 #endif /* _SSZIPARCHIVE_H */

--- a/SSZipArchive/minizip/ioapi.h
+++ b/SSZipArchive/minizip/ioapi.h
@@ -44,11 +44,14 @@
 #include <stdlib.h>
 #include "zlib.h"
 
-#define USE_FILE32API
 #if defined(USE_FILE32API)
 #define fopen64 fopen
 #define ftello64 ftell
 #define fseeko64 fseek
+#elif defined(__APPLE__)
+#define fopen64 fopen
+#define ftello64 ftello
+#define fseeko64 fseeko
 #else
 #ifdef _MSC_VER
  #define fopen64 fopen


### PR DESCRIPTION
Fixed the implicit conversion loses integer precision warnings by using 64-bit file functions and correcting the delegate declaration.