### PR TITLE
Add a delegate for cancelling unzips

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -43,6 +43,7 @@
 - (void)zipArchiveWillUnzipArchiveAtPath:(NSString *)path zipInfo:(unz_global_info)zipInfo;
 - (void)zipArchiveDidUnzipArchiveAtPath:(NSString *)path zipInfo:(unz_global_info)zipInfo unzippedPath:(NSString *)unzippedPath;
 
+- (BOOL)zipArchiveShouldUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 - (void)zipArchiveWillUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 - (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -72,6 +72,7 @@
 	}
 
 	BOOL success = YES;
+	BOOL canceled = NO;
 	int ret = 0;
 	unsigned char buffer[4096] = {0};
 	NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -113,6 +114,15 @@
 			currentPosition += fileInfo.compressed_size;
 
 			// Message delegate
+			if ([delegate respondsToSelector:@selector(zipArchiveShouldUnzipFileAtIndex:totalFiles:archivePath:fileInfo:)]) {
+				if (![delegate zipArchiveShouldUnzipFileAtIndex:currentFileNumber
+                                             totalFiles:(NSInteger)globalInfo.number_entry
+                                            archivePath:path fileInfo:fileInfo]) {
+					success = NO;
+					canceled = YES;
+					break;
+				}
+			}
 			if ([delegate respondsToSelector:@selector(zipArchiveWillUnzipFileAtIndex:totalFiles:archivePath:fileInfo:)]) {
 				[delegate zipArchiveWillUnzipFileAtIndex:currentFileNumber totalFiles:(NSInteger)globalInfo.number_entry
 											 archivePath:path fileInfo:fileInfo];
@@ -299,7 +309,7 @@
 		[delegate zipArchiveDidUnzipArchiveAtPath:path zipInfo:globalInfo unzippedPath:destination];
 	}
 	// final progress event = 100%
-	if ([delegate respondsToSelector:@selector(zipArchiveProgressEvent:total:)]) {
+	if (!canceled && [delegate respondsToSelector:@selector(zipArchiveProgressEvent:total:)]) {
 		[delegate zipArchiveProgressEvent:fileSize total:fileSize];
 	}
 


### PR DESCRIPTION
This adds a zipArchiveShouldUnzipFileAtIndex, which is called before
each call to zipArchiveWillUnzipFileAtIndex, allowing a delegate to
cancel the unzip progress.

Originally I thought this was unnecessary due to https://github.com/soffes/ssziparchive/pull/61 but that one is for zipping, this is for unzipping.