### PR TITLE
Report file size as unsigned long long to delegate

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -46,7 +46,7 @@
 - (void)zipArchiveWillUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 - (void)zipArchiveDidUnzipFileAtIndex:(NSInteger)fileIndex totalFiles:(NSInteger)totalFiles archivePath:(NSString *)archivePath fileInfo:(unz_file_info)fileInfo;
 
-- (void)zipArchiveProgressEvent:(NSInteger)loaded total:(NSInteger)total;
+- (void)zipArchiveProgressEvent:(unsigned long long)loaded total:(unsigned long long)total;
 @end
 
 #endif /* _SSZIPARCHIVE_H */

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -56,8 +56,8 @@
 	}
 
 	NSDictionary * fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil];
-	ZPOS64_T fileSize = fileAttributes.fileSize;
-	ZPOS64_T currentPosition = 0;
+	unsigned long long fileSize = [[fileAttributes objectForKey:NSFileSize] unsignedLongLongValue];
+	unsigned long long currentPosition = 0;
 
 	unz_global_info  globalInfo = {0ul, 0ul};
 	unzGetGlobalInfo(zip, &globalInfo);


### PR DESCRIPTION
Hi.

I came across this due to warnings on loss of precision in implicit type conversions in Xcode 6.
I'm not 100% happy with this patch as I have changed the type in the delegate call. However the file size returned by `-[NSFileManager attributesOfItemAtPath:error:]` is of type `unsigned long long`.
One could argue that it is pretty unlikely to exceed the range of `NSInteger` but this way it is consistent with the type returned by NSFileManager.
If you think it's not worth changing the delegate call declaration I'm happy to add casts to (NSInteger) to silence the warnings.
