### PR TITLE
Update Readme.markdown

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -31,6 +31,9 @@ NSArray *inputPaths = [NSArray arrayWithObjects:
                        [[NSBundle mainBundle] pathForResource:@"photo2" ofType:@"jpg"]
                        nil];
 [SSZipArchive createZipFileAtPath:zippedPath withFilesAtPaths:inputPaths];
+
+// Zipping directory
+[SSZipArchive createZipFileAtPath:zippedPath withContentsOfDirectory:inputPath];
 ```
 
 ## Tests


### PR DESCRIPTION
``createZipFileAtPath:withFilesAtPaths:`` creates an invalid zip for directory, so it’s worth mention that ssziparchive has a separate API for directory.