### PR TITLE
Added option to keep parent directory when compressing directory contents

### DIFF
--- a/SSZipArchive/SSZipArchive.h
+++ b/SSZipArchive/SSZipArchive.h
@@ -26,6 +26,7 @@
 // Zip
 + (BOOL)createZipFileAtPath:(NSString *)path withFilesAtPaths:(NSArray *)filenames;
 + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath;
++ (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath keepParentDirectory:(BOOL)keepParentDirectory;
 
 - (id)initWithPath:(NSString *)path;
 - (BOOL)open;

--- a/SSZipArchive/SSZipArchive.m
+++ b/SSZipArchive/SSZipArchive.m
@@ -322,6 +322,11 @@
 
 
 + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath {
+    return [self createZipFileAtPath:path withContentsOfDirectory:directoryPath keepParentDirectory:NO];
+}
+
+
++ (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath keepParentDirectory:(BOOL)keepParentDirectory {
     BOOL success = NO;
 
     NSFileManager *fileManager = nil;
@@ -338,6 +343,10 @@
             NSString *fullFilePath = [directoryPath stringByAppendingPathComponent:fileName];
             [fileManager fileExistsAtPath:fullFilePath isDirectory:&isDir];
             if (!isDir) {
+                if (keepParentDirectory)
+                {
+                    fileName = [[directoryPath lastPathComponent] stringByAppendingPathComponent:fileName];
+                }
                 [zipArchive writeFileAtPath:fullFilePath withFileName:fileName];
             }
         }


### PR DESCRIPTION
For my app, I needed a way to send all types of data, including file packages. Since these are technically directories, I needed to compress them in order to obtain an NSData blob for them. However, when compressing directories using SSZipArchive, it only enumerates the contents of the directory and adds them to the zip archive individually, which means upon unzipping the file all the individual files are unzipped, rather than the package as a complete unit.

This pull request adds the ability to keep the parent directory when compressing a directory. Essentially, when the provided keepParentDirectory parameter is YES, I prefix all relative file paths with the parent directory, so upon unzipping the parent directory (or package) remains a complete until, with its subfiles contained within it.

To preserve backwards compatibility, I added the method 

    + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath keepParentDirectory:(BOOL)keepParentDirectory;

instead of appending the existing

    + (BOOL)createZipFileAtPath:(NSString *)path withContentsOfDirectory:(NSString *)directoryPath
method.

Of course, I've modified the latter to simply call in to the former, passing NO for the keepParentDirectory parameter.

Cheers!