### PR TITLE
Avoid shadowing variable when extracting ZIP64 extra header fields

### DIFF
--- a/SSZipArchive/minizip/unzip.c
+++ b/SSZipArchive/minizip/unzip.c
@@ -1038,7 +1038,7 @@ local int unz64local_GetCurrentFileInfoInternal (unzFile file,
             /* ZIP64 extra fields */
             if (headerId == 0x0001)
             {
-                                                        uLong uL;
+                                                        uLong uLZip64;
 
                                                                 if(file_info.uncompressed_size == (ZPOS64_T)(unsigned long)-1)
                                                                 {
@@ -1062,7 +1062,7 @@ local int unz64local_GetCurrentFileInfoInternal (unzFile file,
                                                                 if(file_info.disk_num_start == (unsigned long)-1)
                                                                 {
                                                                         /* Disk Start Number */
-                                                                        if (unz64local_getLong(&s->z_filefunc, s->filestream,&uL) != UNZ_OK)
+                                                                        if (unz64local_getLong(&s->z_filefunc, s->filestream,&uLZip64) != UNZ_OK)
                                                                                 err=UNZ_ERRNO;
                                                                 }
 


### PR DESCRIPTION
This popped up as a warning. The variable seems to be unused afterwards anyway, but this is the smallest change I could come up with.