### PR TITLE
PodSpec update

### DIFF
--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SSZipArchive'
-  s.version      = '1.0'
+  s.version      = '1.0.0'
   s.summary      = 'Utility class for zipping and unzipping files on iOS and Mac.'
   s.description  = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS and Mac.'
   s.homepage     = 'https://github.com/soffes/ssziparchive'

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = 'https://github.com/soffes/ssziparchive'
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
   s.author       = { 'Sam Soffes' => 'sam@soff.es' }
-  s.source       = { :git => 'https://github.com/soffes/ssziparchive.git', :tag => "v#{s.version}" }
+  s.source       = { :git => 'https://github.com/soffes/ssziparchive.git', :branch => 'master' }
   s.ios.deployment_target = '4.0'
   s.osx.deployment_target = '10.6'
   s.source_files = 'SSZipArchive/*', 'SSZipArchive/minizip/*'

--- a/SSZipArchive.podspec
+++ b/SSZipArchive.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = 'SSZipArchive'
-  s.version      = '0.3.3'
+  s.version      = '1.0'
   s.summary      = 'Utility class for zipping and unzipping files on iOS and Mac.'
   s.description  = 'SSZipArchive is a simple utility class for zipping and unzipping files on iOS and Mac.'
   s.homepage     = 'https://github.com/soffes/ssziparchive'
   s.license      = { :type => 'MIT', :file => 'LICENSE.txt' }
   s.author       = { 'Sam Soffes' => 'sam@soff.es' }
-  s.source       = { :git => 'https://github.com/soffes/ssziparchive.git', :branch => 'master' }
+  s.source       = { :git => 'https://github.com/soffes/ssziparchive.git', :tag => "v#{s.version}" }
   s.ios.deployment_target = '4.0'
   s.osx.deployment_target = '10.6'
   s.source_files = 'SSZipArchive/*', 'SSZipArchive/minizip/*'


### PR DESCRIPTION
This is an update of podspec file to point to tag v1.0.0. Currently is pointing to an old tag that is not referencing to the last commit from master branch. If you approve this PR you must create a tag v1.0.0 pointing to the last commit from master branch in order to have the latest changes from ssziparchive. In addition you should submit this podspec update to the podspecs repository.
Currently in cocoapods, the podfile is pointing to version 1.0 but there is no such a Tag.